### PR TITLE
create heat model based on python example

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "Heat"
+uuid = "f84b640a-e15b-4457-b8f5-f363600232bd"
+authors = ["CSDMS, Deltares and contributors"]
+version = "0.1.0"
+
+[deps]
+BasicModelInterface = "59605e27-edc0-445a-b93d-c09a3a50b330"
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[compat]
+BasicModelInterface = "0.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/example/example.jl
+++ b/example/example.jl
@@ -1,0 +1,12 @@
+import BasicModelInterface as BMI
+using Heat
+using TOML
+
+path = normpath(@__DIR__, "../example/heat.toml")
+
+m = BMI.initialize(Heat.Model, path)
+
+BMI.update(m)
+BMI.get_current_time(m)
+
+temperature = BMI.get_value_ptr(m, "plate_surface__temperature")

--- a/example/heat.toml
+++ b/example/heat.toml
@@ -1,0 +1,5 @@
+# Heat model configuration
+shape = [6, 8]
+spacing = [1.0, 1.0]
+origin = [0.0, 0.0]
+alpha = 1.0

--- a/src/Heat.jl
+++ b/src/Heat.jl
@@ -1,0 +1,91 @@
+"The 2D heat model."
+module Heat
+
+using Statistics
+using TOML
+using DSP: conv
+
+"""
+    struct Model
+
+Solve the Heat equation on a grid.
+
+# Keywords
+- `shape::Tuple{Int, Int} = (10, 20)`
+    The shape of the solution grid as (*columns*, *rows*).
+- `spacing::Tuple{Float64, Float64} = (1.0, 1.0)`
+    Spacing of grid columns and rows.
+- `origin::Tuple{Float64, Float64} = (0.0, 0.0)`
+    Coordinates of lower left corner of grid.
+- `alpha::Float64 = 1.0`
+    Thermal diffusivity.
+- `time::Float64 = 0.0`
+    Current model time.
+- `time_step::Float64 = 0.0`
+    Time step.
+- `temperature::Matrix{Float64} = rand(shape...)`
+    Temperature on the plate.
+"""
+Base.@kwdef mutable struct Model
+    shape::Tuple{Int,Int} = (10, 20)
+    spacing::Tuple{Float64,Float64} = (1.0, 1.0)
+    origin::Tuple{Float64,Float64} = (0.0, 0.0)
+    alpha::Float64 = 1.0
+    time::Float64 = 0.0
+    time_step::Float64 = minimum(spacing)^2 / (4.0 * alpha)
+    temperature::Matrix{Float64} = rand(shape...)
+end
+
+function Base.show(io::IO, model::Model)
+    time = model.time
+    temp = mean(model.temperature)
+    println(io, "Heat.Model at time = ", time, " and mean temperature = ", temp)
+end
+
+# convert the vectors from the TOML to tuples for the Model
+to_tuple(x::AbstractVector) = Tuple(x)
+to_tuple(x) = x
+
+function Model(config::AbstractDict)
+    kwargs = NamedTuple([Symbol(k) => to_tuple(v) for (k, v) in config])
+    return Model(; kwargs...)
+end
+
+function Model(path::AbstractString)
+    config = TOML.parsefile(path)
+    return Model(config)
+end
+
+"Solve the 2D Heat Equation on a uniform mesh."
+function solve_2d!(model::Model, time_step)
+    (; temperature, spacing, alpha) = model
+
+    dx2, dy2 = spacing .^ 2
+    stencil =
+        [
+            0.0 dy2 0.0
+            dx2 -2(dx2+dy2) dx2
+            0.0 dy2 0.0
+        ] .* alpha .* time_step ./ (2(dx2 * dy2))
+
+    out = conv(temperature, stencil)
+    cutout = @view out[begin+1:end-1, begin+1:end-1]
+    temperature .+= cutout
+    return model
+end
+
+function advance_in_time!(model::Model)
+    solve_2d!(model, model.time_step)
+    model.time += model.time_step
+    return model
+end
+
+function advance_in_time!(model::Model, time_step)
+    solve_2d!(model, time_step)
+    model.time += time_step
+    return model
+end
+
+include("bmi.jl")
+
+end # module Heat

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -1,0 +1,94 @@
+import BasicModelInterface as BMI
+
+const varname = "plate_surface__temperature"
+
+BMI.initialize(::Type{Model}) = Model()
+BMI.initialize(::Type{Model}, x) = Model(x)
+
+BMI.update(m::Model) = advance_in_time!(m)
+
+function BMI.update_until(m::Model, t)
+    time_step = BMI.get_time_step(m)
+    n_steps = (t - BMI.get_current_time(m)) / time_step
+
+    n_whole_steps = floor(Int, n_steps)
+    fractional_step = rem(n_steps, 1) * time_step
+
+    for _ = 1:n_whole_steps
+        advance_in_time!(m)
+    end
+
+    if fractional_step > 0
+        advance_in_time!(m, fractional_step)
+    end
+end
+
+hasvar(name) = name == varname || throw(KeyError(name))
+hasgrid(grid) = grid == 0 || throw(KeyError(grid))
+
+BMI.finalize(m::Model) = m
+
+BMI.get_var_type(m::Model, name) = hasvar(name) && repr(eltype(m.temperature))
+BMI.get_var_units(m::Model, name) = hasvar(name) && "K"
+BMI.get_var_nbytes(m::Model, name) = hasvar(name) && sizeof(m.temperature)
+BMI.get_var_itemsize(m::Model, name) = hasvar(name) && sizeof(eltype(m.temperature))
+BMI.get_var_location(m::Model, name) = hasvar(name) && "node"
+BMI.get_var_grid(m::Model, name) = hasvar(name) && 0
+
+BMI.get_grid_rank(m::Model, grid) = hasgrid(grid) && ndims(m.temperature)
+BMI.get_grid_size(m::Model, grid) = hasgrid(grid) && length(m.temperature)
+
+BMI.get_value_ptr(m::Model, name) = hasvar(name) && m.temperature
+
+function BMI.get_value(m::Model, name, dest)
+    val = BMI.get_value_ptr(m, name)
+    copyto!(dest, val)
+end
+
+function BMI.get_value(m::Model, name, dest, inds)
+    val = BMI.get_value_ptr(m, name)
+    copyto!(dest, val[inds])
+end
+
+function BMI.set_value(m::Model, name, src)
+    val = BMI.get_value_ptr(m, name)
+    val .= src
+    m
+end
+
+function BMI.set_value_at_indices(m::Model, name, inds, src)
+    val = BMI.get_value_ptr(m, name)
+    val[inds] .= src
+    m
+end
+
+BMI.get_component_name(m::Model) = "The 2D Heat Equation"
+
+BMI.get_input_item_count(m::Model) = 1
+BMI.get_output_item_count(m::Model) = 1
+
+BMI.get_input_var_names(m::Model) = [varname]
+BMI.get_output_var_names(m::Model) = [varname]
+
+function BMI.get_grid_shape(m::Model, grid, shape)
+    hasgrid(grid)
+    shape .= size(m.temperature)
+end
+
+function BMI.get_grid_spacing(m::Model, grid, spacing)
+    hasgrid(grid)
+    spacing .= m.spacing
+end
+
+function BMI.get_grid_origin(m::Model, grid, origin)
+    hasgrid(grid)
+    origin .= m.origin
+end
+
+BMI.get_grid_type(m::Model, grid) = hasgrid(grid) && "uniform_rectilinear"
+BMI.get_start_time(m::Model) = 0.0
+BMI.get_end_time(m::Model) = Inf
+BMI.get_current_time(m::Model) = m.time
+BMI.get_time_step(m::Model) = m.time_step
+BMI.get_time_units(m::Model) = "s"
+BMI.get_grid_node_count(m::Model, grid) = BMI.get_grid_size(m, grid)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,63 @@
+import BasicModelInterface as BMI
+using Heat
+using Test
+using TOML
+
+@testset "Heat" begin
+
+    @testset "initialize from defaults" begin
+        m = BMI.initialize(Heat.Model)
+        z0 = BMI.get_value_ptr(m, "plate_surface__temperature")
+        @test all(z0 .>= 0)
+        @test all(z0 .< 1)
+    end
+
+    @testset "initialize from dict" begin
+        config = Dict("shape" => [7, 5])
+        m = BMI.initialize(Heat.Model, config)
+        ndim = BMI.get_grid_rank(m, 0)
+        shape = zeros(Int, ndim)
+        BMI.get_grid_shape(m, 0, shape)
+        @test shape == [7, 5]
+    end
+
+    @testset "initialize from file" begin
+        path = normpath(@__DIR__, "../example/heat.toml")
+        config = TOML.parsefile(path)
+
+        m = BMI.initialize(Heat.Model, path)
+        ndim = BMI.get_grid_rank(m, 0)
+        shape = zeros(Int, ndim)
+        BMI.get_grid_shape(m, 0, shape)
+        @test shape == config["shape"]
+    end
+
+    @testset "update" begin
+        m = Heat.Model()
+        n = 10
+        for _ = 1:n
+            BMI.update(m)
+        end
+        @test BMI.get_current_time(m) ≈ n * BMI.get_time_step(m)
+    end
+
+    @testset "update_until" begin
+        m = Heat.Model()
+        BMI.update_until(m, 10.1)
+        @test BMI.get_current_time(m) ≈ 10.1
+    end
+
+    @testset "value copy" begin
+        m = Heat.Model()
+
+        dest0 = zeros(BMI.get_grid_size(m, 0))
+        dest1 = zeros(BMI.get_grid_size(m, 0))
+
+        z0 = BMI.get_value(m, "plate_surface__temperature", dest0)
+        z1 = BMI.get_value(m, "plate_surface__temperature", dest1)
+
+        @test z0 !== z1
+        @test z0 == z1
+    end
+
+end  # testset "Heat"


### PR DESCRIPTION
I don't want to get ahead of any decisions in https://github.com/csdms/bmi/issues/108, but I needed a simple example of a BMI implementation based on [BasicModelInterface.jl](https://github.com/Deltares/BasicModelInterface.jl), so I thought I might as well port the heat model and put up this PR for visibility.