### PR TITLE
Inconsistency in get_value function

### DIFF
--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -45,7 +45,7 @@ function BMI.get_value(m::Model, name, dest)
     copyto!(dest, val)
 end
 
-function BMI.get_value(m::Model, name, dest, inds)
+function BMI.get_value_at_indices(m::Model, name, dest, inds)
     val = BMI.get_value_ptr(m, name)
     copyto!(dest, val[inds])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,12 +52,19 @@ using TOML
 
         dest0 = zeros(BMI.get_grid_size(m, 0))
         dest1 = zeros(BMI.get_grid_size(m, 0))
+        dest2 = zeros(2)
 
         z0 = BMI.get_value(m, "plate_surface__temperature", dest0)
         z1 = BMI.get_value(m, "plate_surface__temperature", dest1)
 
+        z2 = BMI.get_value_at_indices(m, "plate_surface__temperature", dest2, [1,2])
+
+        @test dest0 === z0
+        @test dest1 === z1
+        @test dest2 === z2
         @test z0 !== z1
         @test z0 == z1
+        @test z0[[1, 2]] == z2
     end
 
 end  # testset "Heat"


### PR DESCRIPTION
Hi! I noticed that the function `get_value` has a second definition with the "inds" argument. According to [the BasicModelInterface.jl specification](https://github.com/Deltares/BasicModelInterface.jl/blob/4ce537cda967c45e7fad484f8dff73900c863658/src/BasicModelInterface.jl#L264), this should be called `get_value_at_indices`.

This PR renames the second definition to `get_value_at_indices`.