### PR TITLE
add continuous integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,14 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
+Aqua = "0.7"
 BasicModelInterface = "0.1"
+DSP = "0.7"
+julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # bmi-example-julia
-An example of wrapping a model written in Julia with a BMI 
+
+An example of wrapping a model written in Julia with a BMI.
+
+This uses the Julia BMI interface package [BasicModelInterface.jl](https://github.com/Deltares/BasicModelInterface.jl).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ import BasicModelInterface as BMI
 using Heat
 using Test
 using TOML
+import Aqua
 
 @testset "Heat" begin
 
@@ -59,5 +60,7 @@ using TOML
         @test z0 !== z1
         @test z0 == z1
     end
+
+    Aqua.test_all(Heat)
 
 end  # testset "Heat"


### PR DESCRIPTION
This uses GitHub actions from the standard https://github.com/julia-actions organization to run the tests on submitted pull requests. Additionally this adds dependabot to keep these Actions up-to-date. This won't happen often so I set it to run monthly.

This also adds Aqua as a test-only dependency to run some extra checks, like if the compatibility of our dependencies is declared, which I added here.