### PR TITLE
use flattened, one-dimensional arrays

### DIFF
--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -38,7 +38,7 @@ BMI.get_var_grid(m::Model, name) = hasvar(name) && 0
 BMI.get_grid_rank(m::Model, grid) = hasgrid(grid) && ndims(m.temperature)
 BMI.get_grid_size(m::Model, grid) = hasgrid(grid) && length(m.temperature)
 
-BMI.get_value_ptr(m::Model, name) = hasvar(name) && m.temperature
+BMI.get_value_ptr(m::Model, name) = hasvar(name) && vec(m.temperature)
 
 function BMI.get_value(m::Model, name, dest)
     val = BMI.get_value_ptr(m, name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,8 @@ import Aqua
     @testset "initialize from defaults" begin
         m = BMI.initialize(Heat.Model)
         z0 = BMI.get_value_ptr(m, "plate_surface__temperature")
+        @test ndims(z0) == 1
+        @test z0 == vec(m.temperature)
         @test all(z0 .>= 0)
         @test all(z0 .< 1)
     end


### PR DESCRIPTION
This addresses the following point from the [BMI best practices](https://bmi.readthedocs.io/en/latest/bmi.best_practices.html#best-practices)

> BMI functions always use flattened, one-dimensional arrays. This avoids any issues stemming from row/column-major indexing when coupling models written in different languages. It’s the developer’s responsibility to ensure that array information is flattened/redimensionalized in the correct order.

As long as you stay in Julia this difference doesn't matter much since Julia supports linear indexing, e.g. `array[3,1] == array[3]`. But @BSchilperoort pointed out this is not the case when doing interop with e.g. numpy.